### PR TITLE
Update TVCameras to support TimingSystem 2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ buildNumber.properties
 
 # Common working directory
 run/
+/.project
+/.classpath

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,3 @@
+/org.eclipse.core.resources.prefs
+/org.eclipse.jdt.core.prefs
+/org.eclipse.m2e.core.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nido</groupId>
     <artifactId>Camera</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.2</version>
     <packaging>jar</packaging>
 
     <name>Camera</name>
@@ -85,13 +85,13 @@
         <dependency>
             <groupId>com.github.Makkuusen</groupId>
             <artifactId>TimingSystem</artifactId>
-            <version>2.0.4</version>
+            <version>2.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nido</groupId>
     <artifactId>Camera</artifactId>
-    <version>2.1</version>
+    <version>2.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Camera</name>
@@ -41,7 +41,7 @@
                             <relocations>
                                 <relocation>
                                     <pattern>co.aikar.commands</pattern>
-                                    <shadedPattern>com.nido.camera.acf</shadedPattern> <!-- Replace this -->
+                                    <shadedPattern>com.nido.camera.acf</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>co.aikar.idb</pattern>
@@ -85,13 +85,13 @@
         <dependency>
             <groupId>com.github.Makkuusen</groupId>
             <artifactId>TimingSystem</artifactId>
-            <version>master-743348b3a7-1</version>
+            <version>2.0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.2-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -111,12 +111,8 @@
         </dependency>
         <dependency>
             <groupId>co.aikar</groupId>
-            <artifactId>acf-paper</artifactId> <!-- Don't forget to replace this -->
-            <version>0.5.1-SNAPSHOT</version> <!-- Replace this as well -->
-            <!-- Example Platform/Version
             <artifactId>acf-paper</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
-            -->
+            <version>0.5.1-SNAPSHOT</version> 
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.github.Makkuusen</groupId>
             <artifactId>TimingSystem</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/nido/camera/Cam.java
+++ b/src/main/java/com/nido/camera/Cam.java
@@ -1,8 +1,8 @@
 package com.nido.camera;
 
 import co.aikar.idb.DbRow;
+import me.makkuusen.timing.system.database.TrackDatabase;
 import me.makkuusen.timing.system.track.Track;
-import me.makkuusen.timing.system.track.TrackDatabase;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;

--- a/src/main/java/com/nido/camera/Utils.java
+++ b/src/main/java/com/nido/camera/Utils.java
@@ -1,7 +1,7 @@
 package com.nido.camera;
 
+import me.makkuusen.timing.system.api.TimingSystemAPI;
 import me.makkuusen.timing.system.track.Track;
-import me.makkuusen.timing.system.track.TrackDatabase;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -20,7 +20,7 @@ import static com.nido.camera.newCamCommand.plugin;
 public abstract class Utils {
 
     public static Track getClosestTrack(Player p) {
-        List<Track> tracks = TrackDatabase.getTracks();
+        List<Track> tracks = TimingSystemAPI.getTracks();
         Location playerLoc = p.getLocation();
         Track closest = null;
         for (Track track: tracks) {


### PR DESCRIPTION
Fixed to support TimingSystem 2.0.3 unless database changes are required.

Plugin loads and appears to work on FrostHex.com